### PR TITLE
In fc23 dracut has moved to /usr/bin

### DIFF
--- a/qubes-artwork.spec
+++ b/qubes-artwork.spec
@@ -65,7 +65,7 @@ make install DESTDIR=%{buildroot}
 
 %post
 /usr/sbin/plymouth-set-default-theme qubes-dark && \
-/usr/sbin/dracut -f || :
+PATH="/sbin:$PATH" dracut -f || :
 xdg-icon-resource forceupdate --theme hicolor || :
 xdg-icon-resource forceupdate --theme oxygen || :
 


### PR DESCRIPTION
Use PATH to find the binary so we continue to work for older versions.
