### PR TITLE
Set BuildArch=noarch since we don't provide any x86_64 files

### DIFF
--- a/qubes-artwork.spec
+++ b/qubes-artwork.spec
@@ -10,6 +10,7 @@ License:	CC BY-SA 4.0 International, GPL v2
 Group:		Qubes
 Vendor:		Invisible Things Lab
 URL:		https://www.qubes-os.org
+BuildArch:	noarch
 
 Provides:	system-logos
 Provides:	redhat-logos


### PR DESCRIPTION
rpmbuild in fc23 fails without this set because it now expects to be
able to extract debug info from architecture specific rpms, and
this package doesn't have any.

Rather than attempt to explicitly disable debug info which may fail
with earlier versions, set noarch since its a more correct fix. I
defer to the packaging experts on whether changing the package type
will cause deployment issues.
