### PR TITLE
plymouth: add qubes-dark-no-echo theme

### DIFF
--- a/plymouth/Makefile
+++ b/plymouth/Makefile
@@ -1,4 +1,4 @@
-DIRS = qubes-dark
+DIRS = qubes-dark qubes-dark-no-echo
 
 all:
 	for dir in $(DIRS); do $(MAKE) -C $$dir $@ || exit 1; done

--- a/plymouth/qubes-dark-no-echo/.gitignore
+++ b/plymouth/qubes-dark-no-echo/.gitignore
@@ -1,0 +1,3 @@
+padlock.png
+qubes-logo-outline.png
+qubes-logo-solid.png

--- a/plymouth/qubes-dark-no-echo/Makefile
+++ b/plymouth/qubes-dark-no-echo/Makefile
@@ -1,0 +1,26 @@
+ALL = $(patsubst %.svg,%.png,$(wildcard *.svg)) padlock.png
+
+all: $(ALL)
+.PHONY: all
+
+%.png: %.svg
+	convert -background none -antialias $< $@
+#	inkscape --export-png=$@ $<
+
+padlock.png:
+	$(PYTHON) ../../bin/mkpadlock.py -s 40 -c 0xee0000 $@
+
+clean:
+	$(RM) $(ALL)
+.PHONY: clean
+
+install:
+	mkdir -p $(DESTDIR)/usr/share/plymouth/themes/qubes-dark-no-echo
+	install -m 0644 -t $(DESTDIR)/usr/share/plymouth/themes/qubes-dark-no-echo \
+		$(ALL) \
+		progress_bar.png \
+		progress_box.png \
+		qubes-dark-no-echo.plymouth \
+		qubes-dark-no-echo.script
+
+.PHONY: install

--- a/plymouth/qubes-dark-no-echo/progress_bar.png
+++ b/plymouth/qubes-dark-no-echo/progress_bar.png
@@ -1,0 +1,1 @@
+../qubes-dark/progress_bar.png

--- a/plymouth/qubes-dark-no-echo/progress_box.png
+++ b/plymouth/qubes-dark-no-echo/progress_box.png
@@ -1,0 +1,1 @@
+../qubes-dark/progress_box.png

--- a/plymouth/qubes-dark-no-echo/qubes-dark-no-echo.plymouth
+++ b/plymouth/qubes-dark-no-echo/qubes-dark-no-echo.plymouth
@@ -1,0 +1,8 @@
+[Plymouth Theme]
+Name=Qubes Dark (no echo)
+Description=Qubes plymouth theme, dark variant, password will not be echoed
+ModuleName=script
+
+[script]
+ImageDir=/usr/share/plymouth/themes/qubes-dark-no-echo
+ScriptFile=/usr/share/plymouth/themes/qubes-dark-no-echo/qubes-dark-no-echo.script

--- a/plymouth/qubes-dark-no-echo/qubes-dark-no-echo.script
+++ b/plymouth/qubes-dark-no-echo/qubes-dark-no-echo.script
@@ -1,0 +1,151 @@
+Window.SetBackgroundTopColor(0.263, 0.294, 0.325);
+Window.SetBackgroundBottomColor(0.179, 0.200, 0.221);
+
+logo.image = Image("qubes-logo-solid.png");
+logo.sprite = Sprite(logo.image);
+logo.opacity_angle = 0;
+
+fun refresh_callback () {
+    logo.sprite.SetX(Window.GetX() + (Window.GetWidth()  - logo.image.GetWidth())  / 2);
+    logo.sprite.SetY(Window.GetY() + (Window.GetHeight() - logo.image.GetHeight()) / 2);
+    logo.sprite.SetOpacity(1);
+}
+  
+Plymouth.SetRefreshFunction(refresh_callback);
+
+#----------------------------------------- Dialogue --------------------------------
+
+status = "normal";
+
+fun dialog_setup(text)
+{
+    local.prompt;
+    local.entry;
+    local.aemsecret;
+    
+    prompt.text = text;
+    prompt.image = Image.Text(text, 1, 1, 1);
+
+    # Try to load AEM secret image, if the file doesn't exists, plymouth shouldn't display anything
+    aemsecret.image = Image("antievilmaid_secret.png");
+
+    entry.image = Image.Text("Password dots will be hidden", 0.8, 0.8, 0.8);
+    
+    prompt.sprite = Sprite(prompt.image);
+    prompt.sprite.SetX(logo.sprite.GetX() + (logo.image.GetWidth() - prompt.image.GetWidth()) / 2);
+    prompt.sprite.SetY(logo.sprite.GetY() + logo.image.GetHeight() + 16);
+    prompt.sprite.SetZ(1);
+    prompt.sprite.text = text;
+
+    entry.sprite = Sprite(entry.image);
+    entry.sprite.SetX(prompt.sprite.GetX() + (prompt.image.GetWidth() - entry.image.GetWidth()) / 2);
+    entry.sprite.SetY(prompt.sprite.GetY() + prompt.image.GetHeight() + 16);
+    entry.sprite.SetZ(1);
+    
+    aemsecret.sprite = Sprite(aemsecret.image);
+    aemsecret.sprite.SetX(entry.sprite.GetX() + (entry.image.GetWidth() - aemsecret.image.GetWidth()) / 2);
+    aemsecret.sprite.SetY(entry.sprite.GetY() + entry.image.GetHeight() + 16);
+    aemsecret.sprite.SetZ(1);
+    
+    global.dialog.prompt = prompt;
+    global.dialog.entry = entry;
+    global.dialog.aemsecret = aemsecret;
+    dialog_opacity(1);
+}
+    
+fun dialog_opacity(opacity)
+{
+    dialog.prompt.sprite.SetOpacity(opacity);
+    dialog.aemsecret.sprite.SetOpacity(opacity);
+    dialog.entry.sprite.SetOpacity(opacity);
+}
+
+fun display_normal_callback()
+{
+    global.status = "normal";
+    if (global.dialog)
+        dialog_opacity(0);
+}
+
+fun display_password_callback(prompt, bullets)
+{
+    if (prompt.SubString(0,32) == "Please enter passphrase for disk") {
+        prompt = "Disk password";
+    }
+
+    global.status = "password";
+    if (!global.dialog) {
+        dialog_setup(prompt);
+    } else {
+        if (global.dialog.prompt.text != prompt) {
+            dialog_opacity(0);
+            global.dialog = NULL;
+            dialog_setup(prompt);
+        } else {
+            dialog_opacity(1);
+        }
+    }
+}
+
+Plymouth.SetDisplayNormalFunction(display_normal_callback);
+Plymouth.SetDisplayPasswordFunction(display_password_callback);
+
+#----------------------------------------- Progress Bar --------------------------------
+
+progress_box.image = Image("progress_box.png");
+progress_box.sprite = Sprite(progress_box.image);
+progress_box.sprite.SetX(Window.GetX() + (Window.GetWidth() - progress_box.image.GetWidth()) / 2);
+progress_box.sprite.SetY(Window.GetHeight() - 50 - progress_box.image.GetHeight() / 2);
+
+progress_bar.original_image = Image("progress_bar.png");
+progress_bar.sprite = Sprite();
+progress_bar.sprite.SetX(progress_box.sprite.GetX() + (progress_box.image.GetWidth()  - progress_bar.original_image.GetWidth())  / 2);
+progress_bar.sprite.SetY(progress_box.sprite.GetY() + (progress_box.image.GetHeight() - progress_bar.original_image.GetHeight()) / 2);
+
+fun progress_callback(duration, progress)
+{
+    if (progress_bar.image.GetWidth() != Math.Int (progress_bar.original_image.GetWidth() * progress)) {
+      progress_bar.image = progress_bar.original_image.Scale(progress_bar.original_image.GetWidth() * progress, progress_bar.original_image.GetHeight());
+      progress_bar.sprite.SetImage(progress_bar.image);
+    }
+}
+
+Plymouth.SetBootProgressFunction(progress_callback);
+
+#----------------------------------------- Quit --------------------------------
+
+fun quit_callback()
+{
+    logo.sprite.SetOpacity(1);
+}
+
+Plymouth.SetQuitFunction(quit_callback);
+
+#----------------------------------------- Message --------------------------------
+
+message_sprites = [];
+message_sprite_count = 0;
+message_sprite_y = 10;
+
+fun display_message_callback(text)
+{
+    my_image = Image.Text(text, 1, 1, 1);
+    message_sprites[message_sprite_count] = Sprite(my_image);
+    message_sprites[message_sprite_count].SetPosition(10, message_sprite_y, 10000);
+    message_sprites[message_sprite_count].text = text;
+    message_sprite_count++;
+    message_sprite_y += my_image.GetHeight();
+}
+
+fun hide_message_callback (text)
+{
+    for (i = 0; i < message_sprite_count; i++) {
+        if (message_sprites[i].text == text)
+            message_sprites[i] = NULL;
+    }
+}
+
+Plymouth.SetDisplayMessageFunction(display_message_callback);
+Plymouth.SetHideMessageFunction(hide_message_callback);
+
+# vim: ts=4 sw=4 et

--- a/plymouth/qubes-dark-no-echo/qubes-logo-outline.svg
+++ b/plymouth/qubes-dark-no-echo/qubes-logo-outline.svg
@@ -1,0 +1,1 @@
+../qubes-dark/qubes-logo-outline.svg

--- a/plymouth/qubes-dark-no-echo/qubes-logo-solid.svg
+++ b/plymouth/qubes-dark-no-echo/qubes-logo-solid.svg
@@ -1,0 +1,1 @@
+../qubes-dark/qubes-logo-solid.svg

--- a/qubes-artwork.spec.in
+++ b/qubes-artwork.spec.in
@@ -801,6 +801,13 @@ xdg-icon-resource forceupdate --theme oxygen || :
 %{_datadir}/plymouth/themes/qubes-dark/qubes-dark.script
 %{_datadir}/plymouth/themes/qubes-dark/qubes-logo-outline.png
 %{_datadir}/plymouth/themes/qubes-dark/qubes-logo-solid.png
+%{_datadir}/plymouth/themes/qubes-dark-no-echo/padlock.png
+%{_datadir}/plymouth/themes/qubes-dark-no-echo/progress_bar.png
+%{_datadir}/plymouth/themes/qubes-dark-no-echo/progress_box.png
+%{_datadir}/plymouth/themes/qubes-dark-no-echo/qubes-dark-no-echo.plymouth
+%{_datadir}/plymouth/themes/qubes-dark-no-echo/qubes-dark-no-echo.script
+%{_datadir}/plymouth/themes/qubes-dark-no-echo/qubes-logo-outline.png
+%{_datadir}/plymouth/themes/qubes-dark-no-echo/qubes-logo-solid.png
 
 
 %files efi


### PR DESCRIPTION
Add a new theme qubes-dark-no-echo which hides disk
decryption password dots

fixes QubesOS/qubes-issues#2199