### PR TITLE
Add stylesheet to anaconda branding

### DIFF
--- a/anaconda/Makefile
+++ b/anaconda/Makefile
@@ -43,6 +43,7 @@ install:
 	mkdir -p $(DESTDIR)/usr/share/anaconda/pixmaps
 	install -m 0644 -t $(DESTDIR)/usr/share/anaconda/pixmaps \
 		$(ALL) \
+		qubes.css \
 		anaconda_header.png \
 		sidebar-bg.png \
 		sidebar-logo.png \

--- a/anaconda/qubes.css
+++ b/anaconda/qubes.css
@@ -1,0 +1,37 @@
+/* Anaconda gtk style overrides for Qubes OS */
+
+/* vendor-specific colors */
+@define-color qubes #3874d8;
+
+/* logo and sidebar classes */
+
+/* The sidebar consists of three parts: a background, a logo, and a product logo,
+ * rendered in that order. The product logo is empty by default and is intended
+ * to be overridden by a stylesheet in product.img.
+ */
+.logo-sidebar {
+    background-image: url('/usr/share/anaconda/pixmaps/sidebar-bg.png');
+    background-color: @qubes;
+    background-repeat: no-repeat;
+}
+
+/* Add a logo to the sidebar */
+.logo {
+    background-image: url('/usr/share/anaconda/pixmaps/sidebar-logo.png');
+    background-position: 50% 20px;
+    background-repeat: no-repeat;
+    background-color: transparent;
+}
+
+/* This is a placeholder to be filled by a product-specific logo. */
+.product-logo {
+    background-image: none;
+    background-color: transparent;
+}
+
+AnacondaSpokeWindow #nav-box {
+    background-color: @qubes;
+    background-image: url('/usr/share/anaconda/pixmaps/topbar-bg.png');
+    background-repeat: repeat;
+    color: white;
+}

--- a/qubes-artwork.spec.in
+++ b/qubes-artwork.spec.in
@@ -858,6 +858,7 @@ xdg-icon-resource forceupdate --theme oxygen || :
 %files anaconda
 # anaconda
 %{_datadir}/anaconda/boot/syslinux-splash.png
+%{_datadir}/anaconda/pixmaps/qubes.css
 %{_datadir}/anaconda/pixmaps/anaconda_header.png
 %{_datadir}/anaconda/pixmaps/progress_first-lowres.png
 %{_datadir}/anaconda/pixmaps/progress_first.png


### PR DESCRIPTION
It is now required, as default stylesheet doesn't point at background
images anymore.