### PR TITLE
Fix setting default background in xfce

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,7 @@
 include:
-- file: /r4.1/gitlab-base.yml
+- file: /r4.3/gitlab-base.yml
   project: QubesOS/qubes-continuous-integration
-- file: /r4.1/gitlab-dom0.yml
+- file: /r4.3/gitlab-host.yml
   project: QubesOS/qubes-continuous-integration
-- file: /r4.1/gitlab-vm.yml
-  project: QubesOS/qubes-continuous-integration
-- file: /r4.2/gitlab-base.yml
-  project: QubesOS/qubes-continuous-integration
-- file: /r4.2/gitlab-host.yml
-  project: QubesOS/qubes-continuous-integration
-- file: /r4.2/gitlab-vm.yml
+- file: /r4.3/gitlab-vm.yml
   project: QubesOS/qubes-continuous-integration

--- a/backgrounds/Makefile
+++ b/backgrounds/Makefile
@@ -36,5 +36,7 @@ install:
 	install -d $(DESTDIR)/usr/share/backgrounds/images
 	ln -s ../wallpapers/Qubes_Steel/contents/images/1920x1080.png $(DESTDIR)/usr/share/backgrounds/default.png
 	ln -s ../../wallpapers/Qubes_Steel/contents/images/1920x1080.png $(DESTDIR)/usr/share/backgrounds/images/default.png
+	gm convert $(DESTDIR)/usr/share/backgrounds/images/default.png \
+		$(DESTDIR)/usr/share/backgrounds/images/default.webp
 
 .PHONY: install

--- a/debian/install
+++ b/debian/install
@@ -630,6 +630,7 @@ usr/share/backgrounds/images/vincent-ledvina-xG3YWsaljIo-unsplash.jpg
 
 usr/share/backgrounds/default.png
 usr/share/backgrounds/images/default.png
+usr/share/backgrounds/images/default.webp
 
 usr/share/wallpapers/Qubes_Blackcurrant/contents/images/1280x1024.png
 usr/share/wallpapers/Qubes_Blackcurrant/contents/images/1600x900.png

--- a/plymouth/Makefile
+++ b/plymouth/Makefile
@@ -10,6 +10,6 @@ clean:
 
 install:
 	for dir in $(DIRS); do $(MAKE) -C $$dir DESTDIR=$(DESTDIR) $@ || exit 1; done
-	mkdir -p $(DESTDIR)/etc/dracut.conf.d/
-	cp plymouth-missing-fonts.conf $(DESTDIR)/etc/dracut.conf.d/
+	mkdir -p $(DESTDIR)/usr/lib/dracut/dracut.conf.d/
+	cp plymouth-missing-fonts.conf $(DESTDIR)/usr/lib/dracut/dracut.conf.d/
 .PHONY: install

--- a/plymouth/plymouth-missing-fonts.conf
+++ b/plymouth/plymouth-missing-fonts.conf
@@ -1,7 +1,7 @@
-install_items+=" /usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf "
-install_items+=" /usr/share/fontconfig/conf.avail/57-dejavu-sans-fonts.conf "
-install_items+=" /etc/fonts/conf.d/57-dejavu-sans-fonts.conf "
+install_items+=" /usr/share/fonts/google-noto-vf/NotoSant[wght].ttf "
+install_items+=" /usr/share/fontconfig/conf.avail/56-google-noto-vf.conf "
+install_items+=" /etc/fonts/conf.d/56-google-noto-sans-vf "
 install_items+=" /etc/fonts/fonts.conf "
 # This unfortunately pulls about 10MB of libraries into initrd, but what can we
 # do... without this, the 'script' plugin cannot output any text message
-install_items+=" $(plymouth --get-splash-plugin-path)/label.so "
+install_items+=" $(plymouth --get-splash-plugin-path)/label-pango.so "

--- a/qubes-artwork.spec.in
+++ b/qubes-artwork.spec.in
@@ -836,7 +836,7 @@ xdg-icon-resource forceupdate --theme oxygen || :
 %{_datadir}/wallpapers/Qubes_Wine/metadata.desktop
 
 %files plymouth
-%{_sysconfdir}/dracut.conf.d/plymouth-missing-fonts.conf
+/usr/lib/dracut/dracut.conf.d/plymouth-missing-fonts.conf
 %{_datadir}/plymouth/themes/qubes-dark/bullet.png
 %{_datadir}/plymouth/themes/qubes-dark/entry.png
 %{_datadir}/plymouth/themes/qubes-dark/padlock.png

--- a/qubes-artwork.spec.in
+++ b/qubes-artwork.spec.in
@@ -688,6 +688,7 @@ xdg-icon-resource forceupdate --theme oxygen || :
 
 %{_datadir}/backgrounds/default.png
 %{_datadir}/backgrounds/images/default.png
+%{_datadir}/backgrounds/images/default.webp
 %{_datadir}/backgrounds/qubes/benjamin-voros-phIFdC6lA4E-unsplash.jpg
 %{_datadir}/backgrounds/qubes/garrett-parker-DlkF4-dbCOU-unsplash.jpg
 %{_datadir}/backgrounds/qubes/jeremy-thomas-pq2DJBntZW0-unsplash.jpg


### PR DESCRIPTION
Xfce package in Fedora uses default.webp instead of default.png
(upstream). Adjust default background placement.

Link: https://src.fedoraproject.org/rpms/xfdesktop/c/e71f34dfded5fddc69158da6095a1bb85ea9bafe
Fixes QubesOS/qubes-issues#8311
QubesOS/qubes-issues#9402