### PR TITLE
Fix wrong logo position on plymouth

### DIFF
--- a/plymouth/qubes-dark/qubes-dark.script
+++ b/plymouth/qubes-dark/qubes-dark.script
@@ -18,8 +18,8 @@ else
 }
 
 fun refresh_callback () {
-    logo.sprite.SetX(Window.GetX() + (Window.GetWidth()  - logo.image.GetWidth())  / 2);
-    logo.sprite.SetY(Window.GetY() + (Window.GetHeight() - logo.image.GetHeight()) / 2);
+    logo.sprite.SetX((Window.GetWidth()  - logo.image.GetWidth())  / 2);
+    logo.sprite.SetY((Window.GetHeight() - logo.image.GetHeight()) / 2);
     logo.sprite.SetOpacity(1);
 }
   
@@ -182,7 +182,7 @@ Plymouth.SetDisplayPromptFunction(display_prompt_callback);
 
 progress_box.image = Image("progress_box.png");
 progress_box.sprite = Sprite(progress_box.image);
-progress_box.sprite.SetX(Window.GetX() + (Window.GetWidth() - progress_box.image.GetWidth()) / 2);
+progress_box.sprite.SetX((Window.GetWidth() - progress_box.image.GetWidth()) / 2);
 progress_box.sprite.SetY(Window.GetHeight() - 50 - progress_box.image.GetHeight() / 2);
 
 progress_bar.original_image = Image("progress_bar.png");


### PR DESCRIPTION
Do not add "window" position to the logo/progress position. On a single
screen system, that position is always (0,0), but on multi-screen system
it's a position of the output. It seems that plymouth calls relevant
callbacks for each output ("window") separately, so there is no need to
add window position manually.

Fixes https://gitlab.freedesktop.org/plymouth/plymouth/-/issues/205