### PR TITLE
Include default background in jxl format too

### DIFF
--- a/backgrounds/Makefile
+++ b/backgrounds/Makefile
@@ -51,5 +51,7 @@ install:
 	ln -s ../../wallpapers/Qubes_Steel/contents/images/1920x1080.png $(DESTDIR)/usr/share/backgrounds/images/default.png
 	gm convert $(DESTDIR)/usr/share/backgrounds/images/default.png \
 		$(DESTDIR)/usr/share/backgrounds/images/default.webp
+	gm convert $(DESTDIR)/usr/share/backgrounds/images/default.png \
+		$(DESTDIR)/usr/share/backgrounds/images/default.jxl
 
 .PHONY: install

--- a/debian/install
+++ b/debian/install
@@ -631,6 +631,7 @@ usr/share/backgrounds/images/vincent-ledvina-xG3YWsaljIo-unsplash.jpg
 usr/share/backgrounds/default.png
 usr/share/backgrounds/images/default.png
 usr/share/backgrounds/images/default.webp
+usr/share/backgrounds/images/default.jxl
 
 usr/share/wallpapers/Qubes_Blackcurrant/contents/images/1280x1024.png
 usr/share/wallpapers/Qubes_Blackcurrant/contents/images/1280x720.png

--- a/qubes-artwork.spec.in
+++ b/qubes-artwork.spec.in
@@ -689,6 +689,7 @@ xdg-icon-resource forceupdate --theme oxygen || :
 %{_datadir}/backgrounds/default.png
 %{_datadir}/backgrounds/images/default.png
 %{_datadir}/backgrounds/images/default.webp
+%{_datadir}/backgrounds/images/default.jxl
 %{_datadir}/backgrounds/qubes/benjamin-voros-phIFdC6lA4E-unsplash.jpg
 %{_datadir}/backgrounds/qubes/garrett-parker-DlkF4-dbCOU-unsplash.jpg
 %{_datadir}/backgrounds/qubes/jeremy-thomas-pq2DJBntZW0-unsplash.jpg


### PR DESCRIPTION
Fedora 42 xfdesktop package expects it:
https://src.fedoraproject.org/rpms/xfdesktop/c/abeefd8f35f648d2125065498cd671d7a8f83736?branch=rawhide

QubesOS/qubes-issues#9807